### PR TITLE
Add MDX blog feature

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,11 +34,11 @@ export default withSentryConfig(
           dirs: ['.'],
         },
         poweredByHeader: false,
-      reactStrictMode: true,
-      pageExtensions: ['tsx', 'ts', 'jsx', 'js', 'md', 'mdx'],
-      experimental: {
-        serverComponentsExternalPackages: ['@electric-sql/pglite'],
-      },
+        reactStrictMode: true,
+        pageExtensions: ['tsx', 'ts', 'jsx', 'js', 'md', 'mdx'],
+        experimental: {
+          serverComponentsExternalPackages: ['@electric-sql/pglite'],
+        },
       }),
     ),
   ),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,12 +4,22 @@ import withBundleAnalyzer from '@next/bundle-analyzer';
 import { withSentryConfig } from '@sentry/nextjs';
 import createJiti from 'jiti';
 import withNextIntl from 'next-intl/plugin';
+import { withMDX } from '@next/mdx';
+import remarkGfm from 'remark-gfm';
 
 const jiti = createJiti(fileURLToPath(import.meta.url));
 
 jiti('./src/libs/Env');
 
 const withNextIntlConfig = withNextIntl('./src/libs/i18n.ts');
+
+const withMDXConfig = withMDX({
+  extension: /\.mdx?$/,
+  options: {
+    remarkPlugins: [remarkGfm],
+    providerImportSource: '@/app/mdx-components',
+  },
+});
 
 const bundleAnalyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
@@ -18,16 +28,19 @@ const bundleAnalyzer = withBundleAnalyzer({
 /** @type {import('next').NextConfig} */
 export default withSentryConfig(
   bundleAnalyzer(
-    withNextIntlConfig({
-      eslint: {
-        dirs: ['.'],
-      },
-      poweredByHeader: false,
+    withMDXConfig(
+      withNextIntlConfig({
+        eslint: {
+          dirs: ['.'],
+        },
+        poweredByHeader: false,
       reactStrictMode: true,
+      pageExtensions: ['tsx', 'ts', 'jsx', 'js', 'md', 'mdx'],
       experimental: {
         serverComponentsExternalPackages: ['@electric-sql/pglite'],
       },
-    }),
+      }),
+    ),
   ),
   {
     // For all available options, see:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "sharp": "^0.33.5",
     "stripe": "^16.12.0",
     "tailwind-merge": "^2.5.4",
+    "@mdx-js/react": "^3.0.0",
+    "gray-matter": "^4.0.3",
+    "remark-gfm": "^3.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -76,6 +79,9 @@
     "@percy/cli": "1.30.1",
     "@percy/playwright": "^1.0.6",
     "@playwright/test": "^1.48.1",
+    "@next/mdx": "^2.0.1",
+    "@mdx-js/loader": "^2.3.0",
+    "@types/mdx": "^2.0.7",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@storybook/addon-essentials": "^8.3.5",

--- a/src/app/[locale]/blog/[slug]/loading.tsx
+++ b/src/app/[locale]/blog/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading…</p>;
+}

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation';
+import { unstable_setRequestLocale } from 'next-intl/server';
+
+import { posts } from '@/content/blog';
+import { ThemeSwitcher } from '@/components/ThemeSwitcher';
+
+export async function generateStaticParams() {
+  return posts.map(post => ({ slug: post.slug }));
+}
+
+export default function BlogPostPage(props: { params: { slug: string; locale: string } }) {
+  unstable_setRequestLocale(props.params.locale);
+  const post = posts.find(p => p.slug === props.params.slug);
+  if (!post) return notFound();
+  const Post = post.component;
+  return (
+    <div className="mx-auto max-w-3xl p-6 prose dark:prose-invert">
+      <div className="flex justify-end"><ThemeSwitcher /></div>
+      <Post />
+    </div>
+  );
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { unstable_setRequestLocale } from 'next-intl/server';
+
+import { posts } from '@/content/blog';
+
+export const metadata = {
+  title: 'Blog',
+};
+
+export default function BlogIndex(props: { params: { locale: string } }) {
+  unstable_setRequestLocale(props.params.locale);
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-4 text-3xl font-bold">Blog</h1>
+      <input
+        type="search"
+        placeholder="Search posts"
+        className="mb-4 w-full rounded border p-2"
+        onChange={e => {
+          const q = e.target.value.toLowerCase();
+          document
+            .querySelectorAll<HTMLAnchorElement>('article')
+            .forEach(article => {
+              article.style.display = article.dataset.title?.includes(q)
+                ? ''
+                : 'none';
+            });
+        }}
+      />
+      <div className="space-y-6">
+        {posts.map(post => (
+          <article key={post.slug} data-title={post.metadata.title.toLowerCase()}>
+            <h2 className="text-xl font-semibold">
+              <Link href={`/${props.params.locale}/blog/${post.slug}`}>{post.metadata.title}</Link>
+            </h2>
+            <p className="text-sm text-gray-500">{post.metadata.date}</p>
+            <p>{post.metadata.summary}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link';
 import { unstable_setRequestLocale } from 'next-intl/server';
 
 import { posts } from '@/content/blog';
+import { BlogList } from '@/components/BlogList';
 
 export const metadata = {
   title: 'Blog',
@@ -13,32 +13,7 @@ export default function BlogIndex(props: { params: { locale: string } }) {
   return (
     <div className="mx-auto max-w-3xl p-6">
       <h1 className="mb-4 text-3xl font-bold">Blog</h1>
-      <input
-        type="search"
-        placeholder="Search posts"
-        className="mb-4 w-full rounded border p-2"
-        onChange={e => {
-          const q = e.target.value.toLowerCase();
-          document
-            .querySelectorAll<HTMLAnchorElement>('article')
-            .forEach(article => {
-              article.style.display = article.dataset.title?.includes(q)
-                ? ''
-                : 'none';
-            });
-        }}
-      />
-      <div className="space-y-6">
-        {posts.map(post => (
-          <article key={post.slug} data-title={post.metadata.title.toLowerCase()}>
-            <h2 className="text-xl font-semibold">
-              <Link href={`/${props.params.locale}/blog/${post.slug}`}>{post.metadata.title}</Link>
-            </h2>
-            <p className="text-sm text-gray-500">{post.metadata.date}</p>
-            <p>{post.metadata.summary}</p>
-          </article>
-        ))}
-      </div>
+      <BlogList posts={posts} locale={props.params.locale} />
     </div>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import '@/styles/global.css';
 
 import type { Metadata } from 'next';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
+import { ThemeProvider } from '@/components/ThemeProvider';
 import { unstable_setRequestLocale } from 'next-intl/server';
 
 import { AllLocales } from '@/utils/AppConfig';
@@ -53,13 +54,11 @@ export default function RootLayout(props: {
     <html lang={props.params.locale} suppressHydrationWarning>
       <body className="bg-background text-foreground antialiased" suppressHydrationWarning>
         {/* PRO: Dark mode support for Shadcn UI */}
-        <NextIntlClientProvider
-          locale={props.params.locale}
-          messages={messages}
-        >
-          {props.children}
-
-        </NextIntlClientProvider>
+        <ThemeProvider>
+          <NextIntlClientProvider locale={props.params.locale} messages={messages}>
+            {props.children}
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/mdx-components.tsx
+++ b/src/app/mdx-components.tsx
@@ -1,0 +1,11 @@
+import type { MDXComponents } from 'mdx/types';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    img: props => <Image {...props} alt={props.alt ?? ''} />,
+    a: props => <Link href={String(props.href)}>{props.children}</Link>,
+    ...components,
+  };
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,18 @@
+import { posts } from '@/content/blog';
+import { getBaseUrl } from '@/utils/Helpers';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  const baseUrl = getBaseUrl();
+  const items = posts
+    .map(p => `<item><title>${p.metadata.title}</title><link>${baseUrl}/blog/${p.slug}</link><description>${p.metadata.summary}</description><pubDate>${p.metadata.date}</pubDate></item>`)  
+    .join('');
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Jibhi.ai Blog</title><link>${baseUrl}/blog</link>${items}</channel></rss>`;
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml',
+    },
+  });
+}

--- a/src/components/BlogList.tsx
+++ b/src/components/BlogList.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { Post } from '@/content/blog';
+
+export function BlogList({ posts, locale }: { posts: Post[]; locale: string }) {
+  const [query, setQuery] = useState('');
+  const filtered = posts.filter(p =>
+    p.metadata.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <>
+      <input
+        type="search"
+        placeholder="Search posts"
+        className="mb-4 w-full rounded border p-2"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      <div className="space-y-6">
+        {filtered.map(post => (
+          <article key={post.slug}>
+            <h2 className="text-xl font-semibold">
+              <Link href={`/${locale}/blog/${post.slug}`}>{post.metadata.title}</Link>
+            </h2>
+            <p className="text-sm text-gray-500">{post.metadata.date}</p>
+            <p>{post.metadata.summary}</p>
+          </article>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ThemeProviderProps } from 'next-themes/dist/types';
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem {...props}>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export function ThemeSwitcher() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="rounded border px-2 py-1"
+    >
+      {theme === 'dark' ? 'Light' : 'Dark'} mode
+    </button>
+  );
+}

--- a/src/content/blog/hello-world.mdx
+++ b/src/content/blog/hello-world.mdx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Hello World',
+  date: '2024-01-01',
+  summary: 'Introducing the blog feature.'
+}
+
+# Hello World
+
+Welcome to **Jibhi.ai** blog powered by MDX.

--- a/src/content/blog/hello-world.mdx
+++ b/src/content/blog/hello-world.mdx
@@ -1,8 +1,4 @@
-export const metadata = {
-  title: 'Hello World',
-  date: '2024-01-01',
-  summary: 'Introducing the blog feature.'
-}
+"use client";
 
 # Hello World
 

--- a/src/content/blog/index.ts
+++ b/src/content/blog/index.ts
@@ -1,0 +1,7 @@
+import HelloWorld, { metadata as helloWorldMeta } from './hello-world.mdx';
+
+export const posts = [
+  { slug: 'hello-world', component: HelloWorld, metadata: helloWorldMeta },
+];
+
+export type Post = typeof posts[number];

--- a/src/content/blog/index.ts
+++ b/src/content/blog/index.ts
@@ -1,7 +1,15 @@
-import HelloWorld, { metadata as helloWorldMeta } from './hello-world.mdx';
+import HelloWorld from './hello-world.mdx';
 
 export const posts = [
-  { slug: 'hello-world', component: HelloWorld, metadata: helloWorldMeta },
+  {
+    slug: 'hello-world',
+    component: HelloWorld,
+    metadata: {
+      title: 'Hello World',
+      date: '2024-01-01',
+      summary: 'Introducing the blog feature.',
+    },
+  },
 ];
 
 export type Post = typeof posts[number];

--- a/src/types/mdx.d.ts
+++ b/src/types/mdx.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="mdx" />
+
+declare module '*.mdx' {
+  let MDXComponent: (props: any) => JSX.Element;
+  export const metadata: Record<string, any>;
+  export default MDXComponent;
+}


### PR DESCRIPTION
## Summary
- enable MDX in Next.js config
- provide MDX components
- integrate ThemeProvider for dark mode
- add example MDX blog post and listing
- include RSS feed and theme switcher

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_b_684bd10ce000833186858633d3a370ac